### PR TITLE
Move innodb_file_per_table to server.cnf.j2

### DIFF
--- a/templates/etc/conf.d/mysqldump.cnf.j2
+++ b/templates/etc/conf.d/mysqldump.cnf.j2
@@ -5,9 +5,3 @@
 quick
 quote-names
 max_allowed_packet      = 16M
-
-{% if mariadb_innodb_file_per_table | d(False) %}
-# Use a separate InnoDB tablespace (the ibdata stuff in /var/lib/mysql)
-# for each database.
-innodb_file_per_table=1
-{% endif %}

--- a/templates/etc/conf.d/server.cnf.j2
+++ b/templates/etc/conf.d/server.cnf.j2
@@ -85,6 +85,11 @@ replicate-wild-do-table = {{ mariadb_replicate_wild_do_table }}
 #
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
+{% if mariadb_innodb_file_per_table | d(False) %}
+# Use a separate InnoDB tablespace (the ibdata stuff in /var/lib/mysql)
+# for each table. (Default since MariaDB >= 5.5)
+innodb_file_per_table=1
+{% endif %}
 
 #
 # * Security Features


### PR DESCRIPTION
##### SUMMARY
During a refactor the variable `innodb_file_per_table` was placed in the wrong configuration template. This change fixed that behavior.

Thanks to @flybyray for reporting it.

Fixes #5

##### ISSUE TYPE
 - Bugfix Pull Request