### PR TITLE
Add support for Debian 10 and Ubuntu 20

### DIFF
--- a/vars/Debian_10.yml
+++ b/vars/Debian_10.yml
@@ -1,0 +1,48 @@
+---
+
+# mariadb related packages
+mariadb_packages:
+  - mariadb-server
+  - mariadb-client
+  - python-mysqldb
+  - pwgen
+
+# mariadb service name
+mariadb_service: mysql
+
+# mariadb server binary
+mariadb_server_bin: /usr/sbin/mysqld
+
+# global mariadb configuration file location
+mariadb_conf: /etc/mysql/my.cnf
+
+# global mariadb configuration directory
+mariadb_conf_dir: /etc/mysql/conf.d
+
+# mariadb configuration files
+mariadb_conf_files:
+  - client
+  - server
+  - mysqld_safe
+  - mysqldump
+
+# roots my.cnf
+mariadb_root_mycnf: /root/.my.cnf
+
+# mariadb slow log file
+mariadb_log_slow: /var/log/mysql/mysql-slow.log
+
+# mariadb error log file
+mariadb_log_error: /var/log/mysql/error.log
+
+# mariadb run directory
+mariadb_run_dir: /var/run/mysqld
+
+# mariadb socket file
+mariadb_socket: '{{ mariadb_run_dir }}/mysqld.sock'
+
+# mariadb anonymous users
+mariadb_anon_user_hosts: []
+
+# MariaDB default character set.
+mariadb_character_set_default: utf8mb4

--- a/vars/Ubuntu_20.yml
+++ b/vars/Ubuntu_20.yml
@@ -1,0 +1,60 @@
+---
+# mariadb related packages
+mariadb_packages:
+  - mariadb-server
+  - mariadb-client
+  - python3-mysqldb
+  - pwgen
+  - python-openssl
+
+# mariadb service name
+mariadb_service: mariadb
+
+# mariadb user
+mariadb_user: mysql
+
+# mariadb server binary
+mariadb_server_bin: /usr/sbin/mysqld
+
+# global mariadb configuration file location
+mariadb_conf: /etc/mysql/mariadb.cnf
+
+# global mariadb configuration directory
+mariadb_conf_dir: /etc/mysql/conf.d
+
+# mariadb configuration files
+mariadb_conf_files:
+  - client
+  - server
+  - mysqld_safe
+  - mysqldump
+
+# configuration directories and files to remove
+mariadb_conf_remove:
+  - /etc/mysql/mariadb.conf.d
+  - /etc/mysql/my.cnf
+  - /etc/mysql/conf.d/mysql.cnf
+
+# roots my.cnf
+mariadb_root_mycnf: /root/.my.cnf
+
+# mariadb slow log file
+mariadb_log_slow: /var/log/mysql/mysql-slow.log
+
+# mariadb error log file
+mariadb_log_error: /var/log/mysql/error.log
+
+# mariadb run directory
+mariadb_run_dir: /var/run/mysqld
+
+# mariadb socket file
+mariadb_socket: "{{ mariadb_run_dir }}/mysqld.sock"
+
+# mariadb anonymous users
+mariadb_anon_user_hosts: []
+
+# mariadb pki path
+mariadb_pki_path: /etc/mysql
+
+# MariaDB default character set.
+mariadb_character_set_default: utf8mb4


### PR DESCRIPTION
##### SUMMARY
Add new vars files to support newer operating systems.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.10.1
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/.local/lib/python3.6/site-packages/ansible
  executable location = /home/user/.local/bin/ansible
  python version = 3.6.8 (default, Apr 16 2020, 01:36:27) [GCC 8.3.1 20191121 (Red Hat 8.3.1-5)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
