### PR TITLE
server.cnf.j2: Add more InnoDB options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,28 @@ mariadb_bind_address: 127.0.0.1
 # mariadb bind port
 mariadb_bind_port: 3306
 
+#
+# Fine Tuning
+#
+
+# Size of the index buffers held in memory:
+mariadb_key_buffer_size: 16M
+
+# Maximum size of a packet or a generated/intermediate string:
+mariadb_max_allowed_packet: 16M
+
+
+#
+# Query Cache Configuration
+#
+
+# Size for which results larger than this are not stored in the query cache:
+mariadb_query_cache_limit: 1M
+
+# Size available to the query cache:
+mariadb_query_cache_size: 16M
+
+
 # MariaDB default character set.
 #
 # .. code-block:: YAML
@@ -93,6 +115,20 @@ mariadb_users: []
 #
 #   mariadb_innodb_file_per_table: true
 #
+
+# Chunk size for InnoDB buffer pool resizing operations:
+#mariadb_innodb_buffer_pool_chunk_size: 128M
+
+# Size of the InnoDB buffer pool, where InnoDB caches table and index data (must
+# be a multiple of
+# mariadb_innodb_buffer_pool_chunk_size * mariadb_innodb_buffer_pool_instances):
+#mariadb_innodb_buffer_pool_size: 128M
+
+# Number of regions that the InnoDB buffer pool is divided into:
+#mariadb_innodb_buffer_pool_instances: {{ 1 if mariadb_innodb_buffer_pool_size < 1*1024*1024*1024 else 8 }}
+
+# Size of each log file in a log group:
+#mariadb_innodb_log_file_size: 5M
 
 # Passphrase for SSL CA private key.
 mariadb_ca_privatekey_passphrase: ''

--- a/templates/etc/conf.d/server.cnf.j2
+++ b/templates/etc/conf.d/server.cnf.j2
@@ -23,8 +23,8 @@ bind-address            = {{ mariadb_bind_address }}
 #
 # * Fine Tuning
 #
-key_buffer              = 16M
-max_allowed_packet      = 16M
+key_buffer              = {{ mariadb_key_buffer_size }}
+max_allowed_packet      = {{ mariadb_max_allowed_packet }}
 thread_stack            = 192K
 thread_cache_size       = 8
 # This replaces the startup script and checks MyISAM tables if needed
@@ -37,8 +37,8 @@ myisam-recover          = BACKUP
 #
 # * Query Cache Configuration
 #
-query_cache_limit       = 1M
-query_cache_size        = 16M
+query_cache_limit       = {{ mariadb_query_cache_limit }}
+query_cache_size        = {{ mariadb_query_cache_size }}
 
 #
 # * Logging and Replication
@@ -90,6 +90,28 @@ replicate-wild-do-table = {{ mariadb_replicate_wild_do_table }}
 # for each table. (Default since MariaDB >= 5.5)
 innodb_file_per_table=1
 {% endif %}
+{% if mariadb_innodb_buffer_pool_chunk_size is defined %}
+
+# Chunk size for InnoDB buffer pool resizing operations:
+innodb_buffer_pool_chunk_size = {{ mariadb_innodb_buffer_pool_chunk_size }}
+{% endif %}
+{% if mariadb_innodb_buffer_pool_instances is defined %}
+
+# Number of regions that the InnoDB buffer pool is divided into:
+innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
+{% endif %}
+{% if mariadb_innodb_buffer_pool_size is defined %}
+
+# Size of the InnoDB buffer pool, where InnoDB caches table and index data (must
+# be a multiple of innodb_buffer_pool_chunk_size*innodb_buffer_pool_instances):
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_log_file_size is defined %}
+
+# Size of each log file in a log group:
+innodb_log_file_size    = {{ mariadb_innodb_log_file_size }}
+{% endif %}
+
 
 #
 # * Security Features


### PR DESCRIPTION
##### SUMMARY

This change adds support for setting the following variables in server.cnf:

* `key_buffer(_size)`
* `max_allowed_packet`
* `query_cache_limit`
* `query_cache_size`
* `innodb_buffer_pool_chunk_size`
* `innodb_buffer_pool_instances`
* `innodb_buffer_pool_size`
* `innodb_log_file_size`

To avoid impacting an existing file, the options are only written to the file if they're actually set.

##### ISSUE TYPE

 - Feature Pull Request

##### ANSIBLE VERSION
```
ansible 2.9.23
config file = /home/martinwe/bfh/moodle/ansible/ansible.cfg
configured module search path = [u'/home/martinwe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']                                       
ansible python module location = /usr/lib/python2.7/dist-packages/ansible
executable location = /usr/bin/ansible
python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]
```

##### ADDITIONAL INFORMATION
*(none)*