### PR TITLE
configuration.yml: Do not leak password when setting up user

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -90,6 +90,7 @@
     priv: '{{ item.priv }}'
     login_unix_socket: '{{ mariadb_socket }}'
     state: present
+  no_log: yes
   when: item.name is defined and item.name and
         item.password is defined and item.password and
         item.priv is defined and item.priv


### PR DESCRIPTION
##### SUMMARY
The user password is currently leaked to Ansible's stdout when applying this role (see below).

This change fixes that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.9.23
config file = /home/martinwe/bfh/moodle/ansible/ansible.cfg
configured module search path = [u'/home/martinwe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/lib/python2.7/dist-packages/ansible
executable location = /usr/bin/ansible
python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]
```

##### ADDITIONAL INFORMATION
```
TASK [mariadb : create users] *******************************************************************************************************
ok: [foobar.net] => (item={u'host': u'localhost', u'password': u'hunter2', u'name': u'AzureDiamond', u'priv': u'AzureDiamond.*:ALL'})
[WARNING]: Module did not set no_log for update_password
```
